### PR TITLE
Having buildozer ignore whl file extensions to prevent bloated apks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ replaceloadingpage:
 
 # Extract the whl file
 extractkolibriwhl:
-	unzip -q "src/kolibri*.whl" "kolibri/*" -d src/
+	unzip -q "src/kolibri*.whl" "kolibri/*" -x "kolibri/dist/cext*" -d src/
 
 # Generate the andoid version
 generateversion:

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -22,6 +22,9 @@ requirements = sqlite3,cryptography,pyopenssl,openssl,python2,pyjnius
 # (str) Icon of the application
 icon.filename = ./assets/logo.png
 
+# (list) Source files to exclude (let empty to not exclude anything)
+source.exclude_exts = whl
+
 # (str) Supported orientation (one of landscape, portrait or all)
 orientation = all
 


### PR DESCRIPTION
Resolves #17 